### PR TITLE
Add simple login and registration forms

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,47 +1,35 @@
 <script setup>
-import HelloWorld from './components/HelloWorld.vue'
-import TheWelcome from './components/TheWelcome.vue'
+import { ref } from 'vue'
+import LoginForm from './components/LoginForm.vue'
+import RegisterForm from './components/RegisterForm.vue'
+
+const page = ref('login')
 </script>
 
 <template>
-  <header>
-    <img alt="Vue logo" class="logo" src="./assets/logo.svg" width="125" height="125" />
-
-    <div class="wrapper">
-      <HelloWorld msg="You did it!" />
-    </div>
-  </header>
-
-  <main>
-    <TheWelcome />
-  </main>
+  <div class="page-toggle">
+    <button :class="{ active: page === 'login' }" @click="page = 'login'">Login</button>
+    <button :class="{ active: page === 'register' }" @click="page = 'register'">Registro</button>
+  </div>
+  <LoginForm v-if="page === 'login'" />
+  <RegisterForm v-else />
 </template>
 
 <style scoped>
-header {
-  line-height: 1.5;
+.page-toggle {
+  text-align: center;
+  margin-bottom: 2rem;
 }
-
-.logo {
-  display: block;
-  margin: 0 auto 2rem;
+.page-toggle button {
+  margin: 0 0.5rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background: var(--color-background-soft);
+  cursor: pointer;
 }
-
-@media (min-width: 1024px) {
-  header {
-    display: flex;
-    place-items: center;
-    padding-right: calc(var(--section-gap) / 2);
-  }
-
-  .logo {
-    margin: 0 2rem 0 0;
-  }
-
-  header .wrapper {
-    display: flex;
-    place-items: flex-start;
-    flex-wrap: wrap;
-  }
+.page-toggle .active {
+  background: hsl(160, 100%, 37%);
+  color: #fff;
 }
 </style>

--- a/src/assets/auth.css
+++ b/src/assets/auth.css
@@ -1,0 +1,37 @@
+.auth-form {
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 2rem;
+  background: var(--color-background-soft);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.auth-form h2 {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.auth-form input {
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+}
+
+.auth-form button {
+  width: 100%;
+  padding: 0.5rem;
+  background-color: hsl(160, 100%, 37%);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.auth-form .message {
+  margin-top: 1rem;
+  text-align: center;
+  color: var(--color-heading);
+}

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -1,0 +1,54 @@
+<script setup>
+import { ref } from 'vue'
+import { api, hashPassword, randomToken } from '../supabase'
+
+const identifier = ref('')
+const password = ref('')
+const message = ref('')
+
+async function login() {
+  message.value = ''
+  try {
+    const hash = await hashPassword(password.value)
+    let users = await api(`/users?username=eq.${encodeURIComponent(identifier.value)}&select=id,password_hash`)
+    if (!users.length) {
+      users = await api(`/users?email=eq.${encodeURIComponent(identifier.value)}&select=id,password_hash`)
+    }
+    if (!users.length) {
+      message.value = 'Usuario no encontrado'
+      return
+    }
+    const user = users[0]
+    if (user.password_hash !== hash) {
+      message.value = 'Contrase\u00f1a incorrecta'
+      return
+    }
+    const token = randomToken()
+    const session = {
+      user_id: user.id,
+      session_token: token,
+      created_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    }
+    await api('/sessions', { method: 'POST', body: JSON.stringify(session) })
+    localStorage.setItem('session_token', token)
+    message.value = 'Sesión iniciada correctamente'
+  } catch (e) {
+    message.value = e.message
+  }
+}
+</script>
+
+<template>
+  <div class="auth-form">
+    <h2>Login</h2>
+    <form @submit.prevent="login">
+      <input v-model="identifier" placeholder="Nombre de usuario o correo" required />
+      <input v-model="password" type="password" placeholder="Contrase\u00f1a" required />
+      <button type="submit">Iniciar sesi\u00f3n</button>
+    </form>
+    <p class="message">{{ message }}</p>
+  </div>
+</template>
+
+<style scoped src="../assets/auth.css"></style>

--- a/src/components/RegisterForm.vue
+++ b/src/components/RegisterForm.vue
@@ -1,0 +1,51 @@
+<script setup>
+import { ref } from 'vue'
+import { api, hashPassword } from '../supabase'
+
+const username = ref('')
+const email = ref('')
+const password = ref('')
+const confirmPassword = ref('')
+const message = ref('')
+
+async function register() {
+  message.value = ''
+  if (password.value !== confirmPassword.value) {
+    message.value = 'Las contrase\u00f1as no coinciden'
+    return
+  }
+  try {
+    const hash = await hashPassword(password.value)
+    const payload = {
+      username: username.value,
+      email: email.value,
+      password_hash: hash,
+      created_at: new Date().toISOString(),
+    }
+    await api('/users', { method: 'POST', body: JSON.stringify(payload) })
+    message.value = 'Registro exitoso. Ahora puedes iniciar sesi\u00f3n.'
+    username.value = ''
+    email.value = ''
+    password.value = ''
+    confirmPassword.value = ''
+  } catch (e) {
+    message.value = e.message
+  }
+}
+</script>
+
+<template>
+  <div class="auth-form">
+    <h2>Registro</h2>
+    <form @submit.prevent="register">
+      <input v-model="username" placeholder="Nombre de usuario" required />
+      <input v-model="email" type="email" placeholder="Correo electr\u00f3nico" required />
+      <input v-model="password" type="password" placeholder="Contrase\u00f1a" required />
+      <input v-model="confirmPassword" type="password" placeholder="Confirmar contrase\u00f1a" required />
+      <button type="submit">Registrarse</button>
+    </form>
+    <p class="message">{{ message }}</p>
+  </div>
+</template>
+
+<style scoped src="../assets/auth.css"></style>

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -1,0 +1,29 @@
+const API_URL = 'https://bidklbjywxkxnotrtnps.supabase.co/rest/v1';
+const API_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJpZGtsYmp5d3hreG5vdHJ0bnBzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA4MTgxMjAsImV4cCI6MjA2NjM5NDEyMH0.kDf2SnmRhvRhl_Hy6_ieFdf6L_qI5YJxt3RhrcKOUTc';
+
+export async function api(path, options = {}) {
+  options.headers = options.headers || {};
+  options.headers['apikey'] = API_KEY;
+  options.headers['Authorization'] = `Bearer ${API_KEY}`;
+  options.headers['Content-Type'] = 'application/json';
+  const res = await fetch(`${API_URL}${path}`, options);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || res.statusText);
+  }
+  return res.json();
+}
+
+export async function hashPassword(password) {
+  const data = new TextEncoder().encode(password);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export function randomToken() {
+  const arr = new Uint8Array(16);
+  crypto.getRandomValues(arr);
+  return Array.from(arr).map((b) => b.toString(16).padStart(2, '0')).join('');
+}


### PR DESCRIPTION
## Summary
- add Supabase helper with REST API calls and password hashing
- add registration and login components
- add simple auth form styles
- update App.vue to toggle between login and register

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68748b7ad1e483249d5306bdce6b9948