### PR TITLE
Fix login session token

### DIFF
--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -26,12 +26,12 @@ async function login() {
     const token = randomToken()
     const session = {
       user_id: user.id,
-      session_id: token,
+      session_token: token,
       created_at: new Date().toISOString(),
       expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
     }
     await api('/sessions', { method: 'POST', body: JSON.stringify(session) })
-    localStorage.setItem('session_id', token)
+    localStorage.setItem('session_token', token)
     message.value = 'Sesión iniciada correctamente'
   } catch (e) {
     message.value = e.message


### PR DESCRIPTION
## Summary
- fix the field name used when creating login sessions

## Testing
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68748e72f7048324b3544b8f20e0cd9f