### PR TITLE
Add static dashboard for player data

### DIFF
--- a/public/dashboard.css
+++ b/public/dashboard.css
@@ -1,0 +1,46 @@
+body {
+  background-color: #121212;
+  font-family: Arial, Helvetica, sans-serif;
+  color: #e0e0e0;
+  margin: 0;
+  padding: 2rem;
+}
+
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.account {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.resources {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 2rem 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 0.5rem;
+}
+
+.resources li {
+  background: #1e1e1e;
+  padding: 1rem;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.logout {
+  background-color: #ff5555;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.logout:hover {
+  background-color: #ff7777;
+}

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dashboard</title>
+    <link rel="stylesheet" href="dashboard.css" />
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  </head>
+  <body>
+    <div class="container">
+      <div id="account" class="account"></div>
+      <ul id="resources" class="resources"></ul>
+      <button id="logout" class="logout">Cerrar sesión</button>
+    </div>
+    <script src="dashboard.js"></script>
+  </body>
+</html>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,0 +1,59 @@
+const SUPABASE_URL = 'https://bidklbjywxkxnotrtnps.supabase.co';
+const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJpZGtsYmp5d3hreG5vdHJ0bnBzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA4MTgxMjAsImV4cCI6MjA2NjM5NDEyMH0.kDf2SnmRhvRhl_Hy6_ieFdf6L_qI5YJxt3RhrcKOUTc';
+
+const client = supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
+
+async function loadData() {
+  const { data: { session } } = await client.auth.getSession();
+  if (!session) {
+    window.location.href = '/login.html';
+    return;
+  }
+  const userId = session.user.id;
+  const { data: profile, error: profileError } = await client
+    .from('users')
+    .select('username')
+    .eq('supabase_auth_id', userId)
+    .single();
+  if (profileError) {
+    console.error(profileError);
+    return;
+  }
+  document.getElementById('account').textContent = profile.username;
+
+  const { data: resources, error: resourceError } = await client
+    .from('player_resources')
+    .select(
+      'chrono_polvo, cristal_etereo, combustible_singularidad, nucleos_potencia, creditos_galacticos, sustancia_x'
+    )
+    .eq('player_id', userId)
+    .single();
+  if (resourceError) {
+    console.error(resourceError);
+    return;
+  }
+  const resourceNames = {
+    chrono_polvo: 'Chrono-Polvo',
+    cristal_etereo: 'Cristal Etéreo',
+    combustible_singularidad: 'Combustible Singularidad',
+    nucleos_potencia: 'Núcleos de Potencia',
+    creditos_galacticos: 'Créditos Galácticos',
+    sustancia_x: 'Sustancia X'
+  };
+  const list = document.getElementById('resources');
+  list.innerHTML = '';
+  Object.keys(resourceNames).forEach((key) => {
+    const li = document.createElement('li');
+    li.textContent = `${resourceNames[key]}: ${resources[key]}`;
+    list.appendChild(li);
+  });
+}
+
+async function logout() {
+  await client.auth.signOut();
+  window.location.href = '/login.html';
+}
+
+document.getElementById('logout').addEventListener('click', logout);
+
+loadData();


### PR DESCRIPTION
## Summary
- add dashboard static page
- style the new dashboard with a dark theme
- include script that loads username and resources from Supabase

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68749649fa7883248e035773199f5987