### PR TITLE
Refactor dashboard to use shared Supabase config

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,9 +1,13 @@
-const SUPABASE_URL = 'https://bidklbjywxkxnotrtnps.supabase.co';
-const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJpZGtsYmp5d3hreG5vdHJ0bnBzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA4MTgxMjAsImV4cCI6MjA2NjM5NDEyMH0.kDf2SnmRhvRhl_Hy6_ieFdf6L_qI5YJxt3RhrcKOUTc';
+import { SUPABASE_URL, SUPABASE_KEY } from '../src/supabase.js';
 
 const client = supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
 
 async function loadData() {
+  const accountEl = document.getElementById('account');
+  const list = document.getElementById('resources');
+  accountEl.textContent = 'Cargando...';
+  list.innerHTML = '';
+
   const { data: { session } } = await client.auth.getSession();
   if (!session) {
     window.location.href = '/login.html';
@@ -11,25 +15,25 @@ async function loadData() {
   }
   const userId = session.user.id;
   const { data: profile, error: profileError } = await client
-    .from('users')
+    .from('public.users')
     .select('username')
     .eq('supabase_auth_id', userId)
     .single();
   if (profileError) {
-    console.error(profileError);
+    accountEl.textContent = profileError.message;
     return;
   }
-  document.getElementById('account').textContent = profile.username;
+  accountEl.textContent = profile.username;
 
   const { data: resources, error: resourceError } = await client
-    .from('player_resources')
+    .from('public.player_resources')
     .select(
       'chrono_polvo, cristal_etereo, combustible_singularidad, nucleos_potencia, creditos_galacticos, sustancia_x'
     )
     .eq('player_id', userId)
     .single();
   if (resourceError) {
-    console.error(resourceError);
+    accountEl.textContent = resourceError.message;
     return;
   }
   const resourceNames = {
@@ -40,8 +44,6 @@ async function loadData() {
     creditos_galacticos: 'Créditos Galácticos',
     sustancia_x: 'Sustancia X'
   };
-  const list = document.getElementById('resources');
-  list.innerHTML = '';
   Object.keys(resourceNames).forEach((key) => {
     const li = document.createElement('li');
     li.textContent = `${resourceNames[key]}: ${resources[key]}`;

--- a/public/login.css
+++ b/public/login.css
@@ -1,0 +1,37 @@
+.auth-form {
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 2rem;
+  background: var(--color-background-soft);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.auth-form h2 {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.auth-form input {
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+}
+
+.auth-form button {
+  width: 100%;
+  padding: 0.5rem;
+  background-color: hsl(160, 100%, 37%);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.auth-form .message {
+  margin-top: 1rem;
+  text-align: center;
+  color: var(--color-heading);
+}

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Login</title>
+    <link rel="stylesheet" href="login.css" />
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  </head>
+  <body>
+    <div id="login" class="auth-form">
+      <h2>Login</h2>
+      <form id="loginForm">
+        <input id="login-email" type="email" placeholder="Correo electr\u00f3nico" required />
+        <input id="login-password" type="password" placeholder="Contrase\u00f1a" required />
+        <button type="submit">Iniciar sesi\u00f3n</button>
+      </form>
+      <p id="login-message" class="message"></p>
+    </div>
+
+    <div id="register" class="auth-form">
+      <h2>Registro</h2>
+      <form id="registerForm">
+        <input id="register-username" placeholder="Nombre de usuario" required />
+        <input id="register-email" type="email" placeholder="Correo electr\u00f3nico" required />
+        <input id="register-password" type="password" placeholder="Contrase\u00f1a" required />
+        <button type="submit">Registrarse</button>
+      </form>
+      <p id="register-message" class="message"></p>
+    </div>
+
+    <script src="login.js"></script>
+  </body>
+</html>

--- a/public/login.js
+++ b/public/login.js
@@ -1,0 +1,57 @@
+const SUPABASE_URL = 'https://YOUR_PROJECT.supabase.co';
+const SUPABASE_KEY = 'YOUR_SUPABASE_ANON_KEY';
+const client = supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
+
+function setMessage(el, msg) {
+  el.textContent = msg;
+}
+
+async function hashPassword(password) {
+  const data = new TextEncoder().encode(password);
+  const buffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+document.getElementById('loginForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = document.getElementById('login-email').value;
+  const password = document.getElementById('login-password').value;
+  const msg = document.getElementById('login-message');
+  setMessage(msg, 'Cargando...');
+  const { data, error } = await client.auth.signInWithPassword({ email, password });
+  if (error || !data.user) {
+    setMessage(msg, error ? error.message : 'Error de autenticaci\u00f3n');
+    return;
+  }
+  window.location.href = '/dashboard.html';
+});
+
+document.getElementById('registerForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const username = document.getElementById('register-username').value;
+  const email = document.getElementById('register-email').value;
+  const password = document.getElementById('register-password').value;
+  const msg = document.getElementById('register-message');
+  setMessage(msg, 'Cargando...');
+  const { data, error } = await client.auth.signUp({ email, password });
+  if (error || !data.user) {
+    setMessage(msg, error ? error.message : 'Error de registro');
+    return;
+  }
+  const userId = data.user.id;
+  const passwordHash = await hashPassword(password);
+  const { error: insertError } = await client.from('public.users').insert({
+    supabase_auth_id: userId,
+    username,
+    password_hash: passwordHash,
+    email
+  });
+  if (insertError) {
+    setMessage(msg, insertError.message);
+    return;
+  }
+  await client.from('public.player_resources').insert({ player_id: userId });
+  window.location.href = '/dashboard.html';
+});

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -1,5 +1,9 @@
-const API_URL = 'https://bidklbjywxkxnotrtnps.supabase.co/rest/v1';
-const API_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJpZGtsYmp5d3hreG5vdHJ0bnBzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA4MTgxMjAsImV4cCI6MjA2NjM5NDEyMH0.kDf2SnmRhvRhl_Hy6_ieFdf6L_qI5YJxt3RhrcKOUTc';
+export const SUPABASE_URL = 'https://bidklbjywxkxnotrtnps.supabase.co';
+export const SUPABASE_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJpZGtsYmp5d3hreG5vdHJ0bnBzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA4MTgxMjAsImV4cCI6MjA2NjM5NDEyMH0.kDf2SnmRhvRhl_Hy6_ieFdf6L_qI5YJxt3RhrcKOUTc';
+
+const API_URL = `${SUPABASE_URL}/rest/v1`;
+const API_KEY = SUPABASE_KEY;
 
 export async function api(path, options = {}) {
   options.headers = options.headers || {};


### PR DESCRIPTION
## Summary
- export Supabase credentials from `src/supabase.js`
- import them in `public/dashboard.js` instead of hardcoding values
- prefix table names with `public.` in dashboard and login scripts

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687497e7cccc8324ba0688710d9cfef2