### PR TITLE
Add login redirect and dashboard data

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -8,12 +8,12 @@ async function loadData() {
   accountEl.textContent = 'Cargando...';
   list.innerHTML = '';
 
-  const { data: { session } } = await client.auth.getSession();
-  if (!session) {
+  const { data: { user } } = await client.auth.getUser();
+  if (!user) {
     window.location.href = '/login.html';
     return;
   }
-  const userId = session.user.id;
+  const userId = user.id;
   const { data: profile, error: profileError } = await client
     .from('public.users')
     .select('username')

--- a/public/login.html
+++ b/public/login.html
@@ -11,11 +11,11 @@
     <div id="login" class="auth-form">
       <h2>Login</h2>
       <form id="loginForm">
-        <input id="login-email" type="email" placeholder="Correo electr\u00f3nico" required />
-        <input id="login-password" type="password" placeholder="Contrase\u00f1a" required />
-        <button type="submit">Iniciar sesi\u00f3n</button>
+        <input id="email" type="email" placeholder="Correo electr\u00f3nico" required />
+        <input id="password" type="password" placeholder="Contrase\u00f1a" required />
+        <button id="loginButton" type="submit">Iniciar sesi\u00f3n</button>
       </form>
-      <p id="login-message" class="message"></p>
+      <p id="messageDisplay" class="message"></p>
     </div>
 
     <div id="register" class="auth-form">

--- a/public/login.js
+++ b/public/login.js
@@ -1,6 +1,11 @@
-const SUPABASE_URL = 'https://YOUR_PROJECT.supabase.co';
-const SUPABASE_KEY = 'YOUR_SUPABASE_ANON_KEY';
+import { SUPABASE_URL, SUPABASE_KEY } from '../src/supabase.js';
 const client = supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
+
+// Input elements
+const emailInput = document.getElementById('email');
+const passwordInput = document.getElementById('password');
+const loginButton = document.getElementById('loginButton');
+const messageDisplay = document.getElementById('messageDisplay');
 
 function setMessage(el, msg) {
   el.textContent = msg;
@@ -16,13 +21,13 @@ async function hashPassword(password) {
 
 document.getElementById('loginForm').addEventListener('submit', async (e) => {
   e.preventDefault();
-  const email = document.getElementById('login-email').value;
-  const password = document.getElementById('login-password').value;
-  const msg = document.getElementById('login-message');
-  setMessage(msg, 'Cargando...');
-  const { data, error } = await client.auth.signInWithPassword({ email, password });
+  setMessage(messageDisplay, 'Cargando...');
+  const { data, error } = await client.auth.signInWithPassword({
+    email: emailInput.value,
+    password: passwordInput.value
+  });
   if (error || !data.user) {
-    setMessage(msg, error ? error.message : 'Error de autenticaci\u00f3n');
+    setMessage(messageDisplay, error ? error.message : 'Error de autenticaci\u00f3n');
     return;
   }
   window.location.href = '/dashboard.html';


### PR DESCRIPTION
## Summary
- update login page element IDs and use them in the script
- redirect to dashboard after sign in/sign up
- share Supabase config and improve dashboard session check

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68749b8212c08324b499548f686063c7