### PR TITLE
Add React auth pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.5.17"
+    "vue": "^3.5.17",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.0",
+    "@supabase/supabase-js": "^2.39.7"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,15 @@
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import LoginRegisterPage from './LoginRegisterPage'
+import DashboardPage from './DashboardPage'
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/login" element={<LoginRegisterPage />} />
+        <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="*" element={<Navigate to="/login" replace />} />
+      </Routes>
+    </BrowserRouter>
+  )
+}

--- a/src/DashboardPage.jsx
+++ b/src/DashboardPage.jsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { supabase } from './supabaseClient'
+import './assets/dashboard.css'
+
+export default function DashboardPage() {
+  const [username, setUsername] = useState('')
+  const [resources, setResources] = useState(null)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const load = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user) {
+        navigate('/login')
+        return
+      }
+
+      const { data: userInfo } = await supabase
+        .from('users')
+        .select('username')
+        .eq('supabase_auth_id', user.id)
+        .single()
+      setUsername(userInfo?.username || '')
+
+      const { data: resourceInfo } = await supabase
+        .from('player_resources')
+        .select('*')
+        .eq('player_id', user.id)
+        .single()
+      setResources(resourceInfo || {})
+    }
+    load()
+  }, [navigate])
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut()
+    navigate('/login')
+  }
+
+  if (!resources) return null
+
+  return (
+    <div className="dashboard">
+      <h1>Bienvenido, {username}</h1>
+      <div className="resources">
+        <div className="resource">Chrono-Polvo: {resources.chrono_polvo}</div>
+        <div className="resource">Cristal Etéreo: {resources.cristal_etereo}</div>
+        <div className="resource">Combustible de Singularidad: {resources.combustible_singularidad}</div>
+        <div className="resource">Núcleos de Potencia: {resources.nucleos_potencia}</div>
+        <div className="resource">Créditos Galácticos: {resources.creditos_galacticos}</div>
+        <div className="resource">Sustancia X: {resources.sustancia_x}</div>
+      </div>
+      <button className="logout" onClick={handleLogout}>Cerrar Sesión</button>
+    </div>
+  )
+}

--- a/src/LoginRegisterPage.jsx
+++ b/src/LoginRegisterPage.jsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { supabase } from './supabaseClient'
+import './assets/auth.css'
+
+export default function LoginRegisterPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState('')
+  const navigate = useNavigate()
+
+  const handleLogin = async () => {
+    setLoading(true)
+    setMessage('')
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    setLoading(false)
+    if (error) {
+      setMessage(error.message)
+    } else {
+      navigate('/dashboard')
+    }
+  }
+
+  const handleRegister = async () => {
+    setLoading(true)
+    setMessage('')
+    const { error } = await supabase.auth.signUp({ email, password })
+    setLoading(false)
+    if (error) {
+      setMessage(error.message)
+    } else {
+      navigate('/dashboard')
+    }
+  }
+
+  return (
+    <div className="auth-form">
+      <h2>Login / Register</h2>
+      <input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button onClick={handleLogin} disabled={loading}>
+        {loading ? '...' : 'Login'}
+      </button>
+      <button onClick={handleRegister} disabled={loading} style={{ marginTop: '1rem' }}>
+        {loading ? '...' : 'Register'}
+      </button>
+      {message && <p className="message">{message}</p>}
+    </div>
+  )
+}

--- a/src/assets/dashboard.css
+++ b/src/assets/dashboard.css
@@ -1,0 +1,27 @@
+.dashboard {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: rgba(0,0,0,0.7);
+  color: #e0e0e0;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+}
+
+.resources {
+  margin-bottom: 2rem;
+}
+
+.resource {
+  padding: 0.5rem;
+  border-bottom: 1px solid #444;
+}
+
+.logout {
+  padding: 0.5rem 1rem;
+  background: #ff3b3b;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './assets/main.css'
+
+ReactDOM.createRoot(document.getElementById('app')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const SUPABASE_URL = 'https://bidklbjywxkxnotrtnps.supabase.co'
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJpZGtsYmp5d3hreG5vdHJ0bnBzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA4MTgxMjAsImV4cCI6MjA2NjM5NDEyMH0.kDf2SnmRhvRhl_Hy6_ieFdf6L_qI5YJxt3RhrcKOUTc'
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY)


### PR DESCRIPTION
## Summary
- add React auth dependencies
- switch index to render React
- initialize Supabase client
- implement login/registration page
- implement authenticated dashboard
- setup router
- add React main entry
- add basic dashboard styles

## Testing
- `npm install` *(fails: 403 Forbidden for @supabase/supabase-js)*

------
https://chatgpt.com/codex/tasks/task_e_68749cee129c832488c2d7c7bf22673c