### PR TITLE
Fix React runtime error

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import LoginRegisterPage from './LoginRegisterPage'
 import DashboardPage from './DashboardPage'

--- a/src/DashboardPage.jsx
+++ b/src/DashboardPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { supabase } from './supabaseClient'
 import './assets/dashboard.css'

--- a/src/LoginRegisterPage.jsx
+++ b/src/LoginRegisterPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { supabase } from './supabaseClient'
 import './assets/auth.css'


### PR DESCRIPTION
## Summary
- add missing `React` imports in React components

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68749f02fa8883249aceb13a79c6555e