### PR TITLE
Improve auth error handling

### DIFF
--- a/src/LoginRegisterPage.jsx
+++ b/src/LoginRegisterPage.jsx
@@ -11,24 +11,40 @@ export default function LoginRegisterPage() {
   const navigate = useNavigate()
 
   const handleLogin = async () => {
+    if (!email.trim() || !password) {
+      setMessage('Please enter both email and password')
+      return
+    }
     setLoading(true)
     setMessage('')
-    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    const { error } = await supabase.auth.signInWithPassword({ email: email.trim(), password })
     setLoading(false)
     if (error) {
-      setMessage(error.message)
+      if (error.status === 400) {
+        setMessage('Invalid login credentials')
+      } else {
+        setMessage(error.message)
+      }
     } else {
       navigate('/dashboard')
     }
   }
 
   const handleRegister = async () => {
+    if (!email.trim() || !password) {
+      setMessage('Please enter both email and password')
+      return
+    }
     setLoading(true)
     setMessage('')
-    const { error } = await supabase.auth.signUp({ email, password })
+    const { error } = await supabase.auth.signUp({ email: email.trim(), password })
     setLoading(false)
     if (error) {
-      setMessage(error.message)
+      if (error.status === 400) {
+        setMessage('Unable to register with provided credentials')
+      } else {
+        setMessage(error.message)
+      }
     } else {
       navigate('/dashboard')
     }


### PR DESCRIPTION
## Summary
- handle missing inputs in `LoginRegisterPage`
- add better messages for 400 errors on login and registration

## Testing
- `npm install` *(fails: 403 Forbidden due to disabled internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6874a00368488324a368694e04efc396